### PR TITLE
Update slack-to-discord instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,18 +73,22 @@ One motivation is Slack's
 ### Running slack-to-discord
 
 If you want to use [slack-to-discord](https://github.com/pR0Ps/slack-to-discord)
-to convert your export to Discord, there are [instructions in the project's
-README](https://github.com/pR0Ps/slack-to-discord#instructions) on setting it
-up and running it. I suggest a slight tweak to those instructions: After installing
-the project, create a `run` script with the following contents:
+to convert your export to Discord, follow [instructions in the project's
+README](https://github.com/pR0Ps/slack-to-discord#instructions).
+
+A slight tweak to the last few instructions on running slack-to-discord:
+I suggest creating a `run` script with the following contents:
+
 ```sh
 #!/bin/sh
 slack-to-discord --zipfile path/to/backup.zip --guild 'Name of Server' --token MTA...
 ```
+
 where the last part is your Discord bot token.
 
-After creating that file, run it via `./run` and wait. You can watch the messages roll
-into the server. Occasionally the script may pause because of Discord's rate limits.
+After creating that file, run it via `./run` and wait.
+You can watch the messages roll into the server.
+Occasionally the script may pause because of Discord's rate limits.
 
 ## History
 

--- a/README.md
+++ b/README.md
@@ -73,38 +73,18 @@ One motivation is Slack's
 ### Running slack-to-discord
 
 If you want to use [slack-to-discord](https://github.com/pR0Ps/slack-to-discord)
-to convert your export to Discord, here is my interpretation of
-[the instructions](https://github.com/pR0Ps/slack-to-discord#instructions):
+to convert your export to Discord, there are [instructions in the project's
+README](https://github.com/pR0Ps/slack-to-discord#instructions) on setting it
+up and running it. I suggest a slight tweak to those instructions: After installing
+the project, create a `run` script with the following contents:
+```sh
+#!/bin/sh
+slack-to-discord --zipfile path/to/backup.zip --guild 'Name of Server' --token MTA...
+```
+where the last part is your Discord bot token.
 
-1. Create a Discord bot under the
-   [applications page](https://discord.com/developers/applications)
-   by clicking "New Application".
-   You probably want the bot to be private (don't click Public).
-2. Write down the Discord bot token.
-3. Invite the bot to your Discord server:
-   * Under OAuth2, URL generator, click the "bot" scope.
-   * Choose the following permissions:
-     * Manage Channels
-     * Send Messages
-     * Create Public Threads
-     * Send Messages in Threads
-     * Embed Links
-     * Attach Files
-     * Manage Messages
-   * Follow the generated URL, choose your server, and click "Authorize".
-4. Clone [the repository](https://github.com/pR0Ps/slack-to-discord)
-5. `pip install discord`
-6. I suggest creating a `run` script with the following contents:
-
-   ```sh
-   #!/bin/sh
-   python slack_to_discord.py --zipfile path/to/backup.zip --guild 'Name of Server' --token MTA...
-   ```
-
-   where the last part is your Discord bot token.
-7. Run the `run` script via `./run` and wait.
-   You can watch the messages roll into the server.
-   Occasionally the script may pause because of Discord's rate limits.
+After creating that file, run it via `./run` and wait. You can watch the messages roll
+into the server. Occasionally the script may pause because of Discord's rate limits.
 
 ## History
 


### PR DESCRIPTION
slack-to-discord now requires a few more permissions and another dependency so the instructions here wouldn't work anymore. In order to make it easier to keep the instructions here up to date, I've mostly deferred to the instructions in the project, while keeping your recommendation to create a script.