### PR TITLE
Get Direct Messages without being admin, and import local files to control fallbacks by reducing image size under Discord limits and attempting zipping other files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # slack-backup
 
 This Python script downloads a backup of all Slack users, all channels
-(*including private channels*), and all messages in those channels.
+(*including private channels and Direct Messages*), and all messages in those channels.
 The produced dump is in the same format produced by an
 [official Slack export of workspace data](https://slack.com/help/articles/201658943-Export-your-workspace-data)
 (which works well for public channels but not private channels).
@@ -26,7 +26,6 @@ One motivation is Slack's
    (I've found the user token to work better than the bot token, but YMMV),
    add the following scopes:
 
-   * `admin` (not sure whether this is necessary)
    * `channels:history`
    * `channels:read`
    * `files:read`
@@ -34,6 +33,10 @@ One motivation is Slack's
    * `groups:read`
    * `users:read`
    * `users:read.email`
+   * `im:history`
+   * `im:read`
+   * `mpim:history`
+   * `mpim:read`
 
    Also write down the Bot User OAuth Token.
    (These directions are based on
@@ -45,24 +48,18 @@ One motivation is Slack's
    see all private channels in the channel list; they need to be invited.)
    If you're using the Bot User Token, you probably need to invite the bot
    to all desired channels.
-8. I recommend also running an
-   [official Slack export of workspace data](https://slack.com/help/articles/201658943-Export-your-workspace-data).
-   In JSON files containing file uploads, you'll see URLs ending with
-   `?t=xoxe-...`.  Write down that token too.
-   (This is a temporary file access token; I think it lasts 7 days.)
-9. Then I suggest creating a `run` script with the following contents:
+8. Then I suggest creating a `run` script with the following contents:
 
    ```sh
    #!/bin/sh
    export TOKEN='xoxp-...'  # Bot User OAuth Token
    # Optional settings: (you can omit them)
-   export FILE_TOKEN='xoxe-...'  # file access export token from previous step
    export DOWNLOAD=1  # download all message files locally too
    python slack_backup.py
    ```
-10. Run the `run` script via `./run` and wait.
-11. The output will be in a created `backup` subdirectory.
-12. To produce a `backup.zip` file in the same format as a Slack export,
+9. Run the `run` script via `./run` and wait.
+10. The output will be in a created `backup` subdirectory.
+11. To produce a `backup.zip` file in the same format as a Slack export,
     do the following in a shell (assuming you have `zip` installed):
 
     ```sh
@@ -95,5 +92,5 @@ Occasionally the script may pause because of Discord's rate limits.
 This code was initially based on a
 [gist](https://gist.github.com/benoit-cty/a5855dea9a4b7af03f1f53c07ee48d3c)
 by [Benoit Courty](https://gist.github.com/benoit-cty).
-This fork adds channel listing, user listing, file downloads, and
+This fork adds channel listing (including Direct Messages), user listing, file downloads, and
 making the output format compatible with standard Slack dumps.

--- a/README.md
+++ b/README.md
@@ -6,11 +6,9 @@ The produced dump is in the same format produced by an
 [official Slack export of workspace data](https://slack.com/help/articles/201658943-Export-your-workspace-data)
 (which works well for public channels but not private channels).
 
-The intended use-case for moving old Slack content over to a new
-Discord server via
-[slack-to-discord](https://github.com/pR0Ps/slack-to-discord)
-(tested) or
-[Slackord2](https://github.com/thomasloupe/Slackord2) (untested).
+The intended use-case is for moving old Slack content over to a new
+Discord server via bluescopedata's [slack-to-discord](https://github.com/bluescopedata/slack-to-discord) (This is an updated fork of [slack-to-discord](https://github.com/pR0Ps/slack-to-discord). It is necessary to use this fork with this update as it it imports files from your local backup, rather than from the slack url, perfoming some image shrinking and zipping in case of oversized files, before falling back to slack. It also supports the Direct Message uploads.)
+
 One motivation is Slack's
 [change in limits to the free plan](https://slack.com/help/articles/7050776459923-Pricing-changes-for-the-Pro-plan-and-updates-to-the-Free-plan).
 
@@ -53,7 +51,6 @@ One motivation is Slack's
    ```sh
    #!/bin/sh
    export TOKEN='xoxp-...'  # Bot User OAuth Token
-   # Optional settings: (you can omit them)
    export DOWNLOAD=1  # download all message files locally too
    python slack_backup.py
    ```
@@ -69,9 +66,9 @@ One motivation is Slack's
 
 ### Running slack-to-discord
 
-If you want to use [slack-to-discord](https://github.com/pR0Ps/slack-to-discord)
+If you want to use [slack-to-discord](https://github.com/bluescopedata/slack-to-discord)
 to convert your export to Discord, follow [instructions in the project's
-README](https://github.com/pR0Ps/slack-to-discord#instructions).
+README](https://github.com/bluescopedata/slack-to-discord#instructions).
 
 A slight tweak to the last few instructions on running slack-to-discord:
 I suggest creating a `run` script with the following contents:

--- a/slack_backup.py
+++ b/slack_backup.py
@@ -3,7 +3,12 @@
 # https://gist.github.com/benoit-cty/a5855dea9a4b7af03f1f53c07ee48d3c
 
 import urllib.request, urllib.parse
+from urllib.error import HTTPError
+import http.client
+from random import randint
+from time import sleep
 
+import json
 import os
 TOKEN = os.environ['TOKEN']  # provide bot or user token (preferably user)
 FILE_TOKEN = os.environ.get('FILE_TOKEN')  # file access token via public dump
@@ -15,41 +20,6 @@ from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
 client = WebClient(token=TOKEN)
-indent = 0
-
-def slack_list(field, info, operation, **dargs):
-  # Most WebClient methods are paginated, returning the first n results
-  # along with a "next_cursor" pointer to fetch the rest.
-  print(f'{" " * indent}Fetching {info or field}...')
-  try:
-    items = []
-    cursor = None
-    while True:
-      result = operation(cursor=cursor, **dargs)
-      items += result[field]
-      if 'response_metadata' not in result: break
-      cursor = result['response_metadata']['next_cursor']
-      if not cursor: break
-      print(f'{" " * indent}  Fetching more...')
-    print(f'{" " * indent}  Fetched {len(items)} {field}')
-  except SlackApiError as e:
-    print("ERROR USING CONVERSATION: {}".format(e))
-  return items
-
-def all_channels():
-  return slack_list('channels', 'all channels',
-    client.conversations_list, types='public_channel, private_channel')
-
-def all_channel_members(channel):
-  return slack_list('members', f'all members in channel {channel["name"]}',
-    client.conversations_members, channel=channel['id'])
-
-def all_channel_messages(channel):
-  return slack_list('messages', f'all messages from channel {channel["name"]}',
-    client.conversations_history, channel=channel['id'])
-
-def all_users():
-  return slack_list('members', 'all users', client.users_list)
 
 import json
 def save_json(data, filename):
@@ -58,64 +28,117 @@ def save_json(data, filename):
   with open(filename, 'w') as outfile:
     json.dump(data, outfile, indent=2)
 
-def backup_channel(channel):
+def backup_channel(channel_name, channel_id):
   try:
-    all_messages = all_channel_messages(channel)
-    save_json(all_messages, f'backup/{channel["name"]}/all.json')
+    print('Getting messages from', channel_name)
+    # Call the conversations.history method using the WebClient
+    # conversations.history returns the first 100 messages by default
+    # These results are paginated
+    result = client.conversations_history(channel=channel_id)
+    all_messages = []
+    all_messages += result["messages"]
+    while result['has_more']:
+      print("\tGetting more...")
+      try:
+        result = client.conversations_history(channel=channel_id, cursor=result['response_metadata']['next_cursor'])
+        all_messages += result["messages"]
+
+        # take a nap
+        sleep(1)
+      except http.client.IncompleteRead as e:
+        print(f'IncompleteRead {channel_name}')
+      except Exception as result:
+        print("Unknown error" + str(result))
+    print(f'  Downloaded {len(all_messages)} messages from {channel_name}.')
 
     # Rewrite private URLs to have token, like Slack's public dump
     filenames = {'all.json'}  # avoid overwriting json
     count = 0
     for message in all_messages:
+
+      # define a message by its client_msg_id, or default to the ts (Slack's weird timestamp)
+      msg_id = message.get('client_msg_id', message.get('ts'))
+
+      # if there is no msg_id for whatever reason
+      if msg_id == 'none':
+          print(f' {message} ')
+
       if 'files' in message:
+
+        # create the backup/<channel>/<msg_id> directory, so we can put files in there
+        # and persist the file names that were originally set, they display inline!
+        os.makedirs(f'backup/{channel_name}/{msg_id}', mode=0o700, exist_ok=True)
+
         for file in message['files']:
           count += 1
           for key, value in list(file.items()):
-            if (key.startswith('url_private') or key.startswith('thumb')) \
-               and isinstance(value, str) and value.startswith('https://'):
+            if (key.startswith('url_private') and isinstance(value, str)) and value.startswith('https://'):
               if FILE_TOKEN:
                 file[key] = value + '?t=' + FILE_TOKEN
               if DOWNLOAD and not key.endswith('_download'):
                 filename = os.path.basename(urllib.parse.urlparse(value).path)
-                if filename in filenames:
-                  i = 0
-                  base, ext = os.path.splitext(filename)
-                  def rewrite():
-                    return base + '_' + str(i) + ext
-                  while rewrite() in filenames:
-                    i += 1
-                  filename = rewrite()
                 filenames.add(filename)
                 # https://api.slack.com/types/file#authentication
-                with urllib.request.urlopen(urllib.request.Request(value,
-                       headers={'Authorization': 'Bearer ' + TOKEN})) as infile:
-                  with open(f'backup/{channel["name"]}/{filename}', 'wb') as outfile:
-                    outfile.write(infile.read())
-                file[key + '_file'] = f'{channel["name"]}/{filename}'
+                try:
+                  with urllib.request.urlopen(urllib.request.Request(file[key])) as infile:
+                    with open(f'backup/{channel_name}/{msg_id}/{filename}', 'wb') as outfile:
+                      outfile.write(infile.read())
+                except http.client.IncompleteRead as e:
+                  print(f' incomplete read {file[key]}')
+                  outfile.write(e.partial)
+                except FileNotFoundError as e:
+                  print(f' FileNotFoundError: {e} ')
+                  print(f' Error getting file: {filename}, from url {file[key]} ')
+                except HTTPError as e:
+                  print(f' HTTPError: {e} ')
+                except Exception as e:
+                  print(f' Unknown: {e} ')
+
+                file[key + '_file'] = f'{channel_name}/{filename}'
+
+          # avoid slacks rate limit and/or timeouts, take a quick nap
+          sleep(randint(1,3))
+
     verbs = []
     if DOWNLOAD: verbs.append('Downloaded')
     if FILE_TOKEN: verbs.append('Linked')
-    if verbs: print(f'  {" & ".join(verbs)} {count} files from messages in {channel["name"]}.')
+    if verbs: print(f'  {" & ".join(verbs)} {count} files from messages in {channel_name}.')
 
-    if count and FILE_TOKEN:
-      save_json(all_messages, f'backup/{channel["name"]}/all.json')
-
+    save_json(all_messages, f'backup/{channel_name}/all.json')
   except SlackApiError as e:
       print("Error using conversation: {}".format(e))
 
 def backup_all_channels():
-  global indent
-  channels = all_channels()
-  indent += 2
-  for channel in channels:
-    channel['members'] = all_channel_members(channel)
-  indent -= 2
+  try:
+    print('Listing channels')
+    result = client.conversations_list(
+        types="public_channel, private_channel",
+        limit=1000,
+    )
+    channels = result['channels']
+    print(f'  Got {len(channels)} channels')
+    for channel in channels:
+      result = client.conversations_members(
+        channel=channel['id'],
+      )
+      channel['members'] = result['members']
+      print(f'  Got {len(result["members"])} members for channel {channel["name"]}')
+  except SlackApiError as e:
+    print("Error using conversation: {}".format(e))
+    return
   save_json(channels, 'backup/channels.json')
   for channel in channels:
-    backup_channel(channel)
+    backup_channel(channel['name'], channel['id'])
 
 def backup_all_users():
-  users = all_users()
+  try:
+    print('Listing users')
+    result = client.users_list()
+    users = result['members']
+    print(f'  Got {len(users)} users')
+  except SlackApiError as e:
+    print("Error using conversation: {}".format(e))
+    return
   save_json(users, 'backup/users.json')
 
 if __name__ == "__main__":


### PR DESCRIPTION

This PR builds on the work by @kingsloi at https://github.com/kingsloi/slack-backup.git, and makes a couple of improvements.
1) Direct Messages and Multiparty Direct Messages are now included in the download.
	- unamed Slack DMs are renamed as a hyphenated list of the members, plus the unique channel id. (This is often necessary to avoid naming issues with Direct Messages as they can conflict in some cases - for example if you have a SlackBot app, you will have two Direct Message chats with your username as the only member.)
	- eg. "user1-user2-IDUVJDJV83G"
2) There is now only one token required: the Bot User OAuth Token
	- it is no longer a requirement to be an admin or owner of the workspace to download all messages and files from channels where the user is a member
	- this reduces the number of steps required in the setup
	- "admin" scope is not necessary
	- four additional scopes are necessary
		im:history
		View messages and other content in a user’s direct messages

		im:read
		View basic information about a user’s direct messages

		mpim:history
		View messages and other content in a user’s group direct messages

		mpim:read
		View basic information about a user’s group direct messages
3) One caveat is that now this PR must be used with https://github.com/bluescopedata/slack-to-discord.git, to support Direct Messages and local file uploads, instead of imports from slack urls. I realise this is not ideal for some users, but in my case (and I'm sure others will face this), I struggled to get the slack image token as I am not an admin of the slack workspace I wanted to back up. I also added a fallback system to the import in https://github.com/bluescopedata/slack-to-discord.git, so that if images are too large they are redued in size until they are under the limit, and if other data is over the limit, it is zipped and attempted, with slack's url pointers as a fallback. I've found this sufficient for my case.		
